### PR TITLE
feat(launcher): autostart end-to-end with headless model resolution +…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and follows [Semantic Versioning](https://semver.org/).
 - UI: **Reply / Compose / Rewrite** flows with **tone** and **length** presets; one-click copy; safe validation.
 - Launcher: `/api/stream` now accepts structured fields `{ flow, tone, length, subject, context, instructions }`.
 - Launcher: prompt builder that derives a clear **system** and **user** message for upstream.
+- Launcher autostart **end-to-end**: if `USBLLM_AUTOSTART=1` and `USBLLM_LLAMA_BIN` are set, the launcher now starts `llama-server` using either:
+  - `USBLLM_MODEL_FILE` (explicit absolute/relative `.gguf`), **or**
+  - headless resolution via `USBLLM_MODEL_ID` + `USBLLM_MODELS_DIR` (from `models/registry.json`).
+- Optional runtime flags passed to `llama-server` when provided:
+  - `USBLLM_CTX_SIZE` → `--ctx-size`
+  - `USBLLM_THREADS` → `--threads`
+  - `USBLLM_TEMP_DIR` → `--temp-dir`
+  - `USBLLM_LOG_DISABLE=1` → `--log-disable`
+- Structured request body support for `/api/stream` (bridge builds a prompt from `{flow,tone,length,subject,context,instructions}`), while keeping `prompt` for legacy callers.
 
 ### Changed
 
@@ -54,6 +63,8 @@ and follows [Semantic Versioning](https://semver.org/).
 - Docs: `USAGE.md` (case fix from `USAGE.MD`) and expanded autostart instructions for **model ID** flow.
 - Upstream: accepts an optional **system override** so the server can control tone/length semantics consistently across modes.
 - Docs: updated `USAGE.md` with structured curl examples for **compose** and **reply**.
+- `/api/stream` autostart branch now uses **resolved local model** when `USBLLM_MODEL_FILE` is not set.
+- If local model is **missing/misconfigured**, we emit an SSE `error` and **fall back to Stub**, preserving a working UX instead of failing hard.
 
 **Fixed**
 

--- a/apps/launcher/src/config.ts
+++ b/apps/launcher/src/config.ts
@@ -7,19 +7,19 @@ export type LauncherConfig = {
   // Optional supervisor/autostart (used only when upstreamUrl is null)
   autostart: boolean; // USBLLM_AUTOSTART=true|1
   binPath: string | null; // path to llama-server binary
-  modelFile: string | null; // explicit path to .gguf (overrides headless resolver)
+  modelFile: string | null; // path to .gguf (explicit override)
   preferPort: number | null; // desired port, else auto-pick
 
   // Headless local model resolution (no picker)
   modelId: string | null; // matches models/registry.json
-  modelsDir: string; // where .gguf is expected
+  modelsDir: string; // directory where .gguf is expected
   uiAllowPicker: boolean; // exposed via /v1/models for dev toggles (default false)
 
-  // Optional tuning flags passed to llama-server (only if defined)
+  // Llama flags (optional)
   ctxSize: number | null; // USBLLM_CTX_SIZE
   threads: number | null; // USBLLM_THREADS
   tempDir: string | null; // USBLLM_TEMP_DIR
-  logDisable: boolean; // USBLLM_LOG_DISABLE
+  logDisable: boolean; // USBLLM_LOG_DISABLE=1/true
 };
 
 function toBool(s: string | undefined): boolean {
@@ -28,7 +28,7 @@ function toBool(s: string | undefined): boolean {
   return v === '1' || v === 'true' || v === 'yes';
 }
 
-function toNum(s: string | undefined): number | null {
+function toIntOrNull(s: string | undefined): number | null {
   if (!s) return null;
   const n = Number(s);
   return Number.isFinite(n) ? n : null;
@@ -42,16 +42,16 @@ export function loadConfig(): LauncherConfig {
   const autostart = toBool(process.env.USBLLM_AUTOSTART);
   const binPath = (process.env.USBLLM_LLAMA_BIN || '').trim() || null;
   const modelFile = (process.env.USBLLM_MODEL_FILE || '').trim() || null;
-  const preferPort = toNum(process.env.USBLLM_LLAMA_PORT);
+  const preferPort = process.env.USBLLM_LLAMA_PORT ? Number(process.env.USBLLM_LLAMA_PORT) : null;
 
-  // Headless model resolution
+  // Headless resolution
   const modelId = (process.env.USBLLM_MODEL_ID || '').trim() || null;
   const modelsDir = (process.env.USBLLM_MODELS_DIR || 'models').trim() || 'models';
   const uiAllowPicker = toBool(process.env.USBLLM_UI_ALLOW_PICKER); // default false
 
-  // Optional server tuning flags
-  const ctxSize = toNum(process.env.USBLLM_CTX_SIZE);
-  const threads = toNum(process.env.USBLLM_THREADS);
+  // Llama flags
+  const ctxSize = toIntOrNull(process.env.USBLLM_CTX_SIZE);
+  const threads = toIntOrNull(process.env.USBLLM_THREADS);
   const tempDir = (process.env.USBLLM_TEMP_DIR || '').trim() || null;
   const logDisable = toBool(process.env.USBLLM_LOG_DISABLE);
 


### PR DESCRIPTION
… flags

Use USBLLM_MODEL_ID(+MODELS_DIR) when MODEL_FILE not set; pass optional flags (--ctx-size/--threads/--temp-dir/--log-disable); structured request for /api/stream; safe SSE error + Stub fallback; changelog updated.