### PR TITLE
feat(models): add model helper CLI for setup and verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,11 @@ and follows [Semantic Versioning](https://semver.org/).
 - Node SEA packaging: single-file launcher binaries for macOS and Windows (`pack:sea:mac`, `pack:sea:win`).
 - `docs/PACKAGING.md`: USB layout, SEA build steps, and distribution guidance.
 - `packages/golden`: Golden tasks & offline quality harness CLI with 25 email tasks, basic heuristics (length, greeting, CTA), and CI-friendly exit codes. Supports Stub mode and real model testing.
-- Root convenience scripts: `npm run golden`, `npm run golden:stub`, `npm run golden:quick`.
+- Root convenience script: `npm run golden`.
 - Optional CI job (commented) for running golden tasks in Stub mode.
+- `scripts/model-helper.mjs`: CLI to add/list models with SHA-256 verification.
+- Root scripts: `models:add`, `models:list`, `models:help`.
+- Improved model setup workflow in `docs/MODELS.md` with helper commands and testing instructions.
 
 ### Changed
 
@@ -62,3 +65,5 @@ and follows [Semantic Versioning](https://semver.org/).
 - Docs: updated `USAGE.md` with structured curl examples for **compose** and **reply**.
 - Build output directories (`dist-sea/`, `build/`) are now excluded from lint/format checks.
 - Packaging: SEA config now correctly bundles the launcher into a single `.cjs` file before embedding.
+- `README.md`: updated models section to reference `models:add` and golden tasks workflow.
+- `docs/MODELS.md`: complete rewrite with model helper CLI workflow, testing instructions, and troubleshooting.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See **[docs/USAGE.md](docs/USAGE.md)** for:
 - **External upstream** (you run `llama-server`)
 - **Autostart** (launcher starts `llama-server` given a binary + model)
 
-See **[docs/MODELS.md](docs/MODELS.md)** to choose and verify a model by RAM tier (Starter / Standard / Pro).
+See **[docs/MODELS.md](docs/MODELS.md)** to choose and set up a model by RAM tier (Starter / Standard / Pro). Use `npm run models:add` to copy and verify `.gguf` files, then test with `npm run golden`.
 
 ---
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,62 +1,284 @@
-# Models — USB-LLM
+# Models Guide
 
-USB-LLM ships **no model weights**. Choose one model below based on your computer’s RAM, download its `.gguf` file, and (optionally) verify it.
-
-> Not sure which to choose? Pick **Starter**. You can switch later without reinstalling.
+USB-LLM runs local **GGUF** models via **llama.cpp** (`llama-server`). You bring the model. This guide helps you choose one and set it up.
 
 ---
 
-## Which model should I pick?
+## RAM-Based Model Tiers
 
-| Tier         | Pick this if…                | RAM guidance | License    | Notes                                             |
-| ------------ | ---------------------------- | ------------ | ---------- | ------------------------------------------------- |
-| **Starter**  | You’re unsure / older laptop | ≤ **8 GB**   | **MIT**    | Smallest; runs almost anywhere.                   |
-| **Standard** | Typical modern laptop        | **8–16 GB**  | Apache-2.0 | Better phrasing; good default for 2020+ machines. |
-| **Pro**      | Newer machine, best quality  | ≥ **16 GB**  | Apache-2.0 | Strongest tone/clarity at this size.              |
+We've tested three tiers optimized for different hardware:
 
-**How to check RAM**
+### Starter (4–8 GB RAM)
 
-- **Windows:** Settings → System → About → _Installed RAM_
-- **macOS:**  → About This Mac → _Memory_
+- **Model:** Phi-3 Mini Instruct (Q4_K_M)
+- **File:** `phi-3-mini-instruct-q4_k_m.gguf`
+- **Context:** 4096 tokens
+- **License:** MIT
+- **Best for:** Most laptops, fast iteration, good for short emails
 
----
+### Standard (8–16 GB RAM)
 
-## Models in this project
+- **Model:** Mistral 7B Instruct (Q4_K_M)
+- **File:** `mistral-7b-instruct-q4_k_m.gguf`
+- **Context:** 8192 tokens
+- **License:** Apache-2.0
+- **Best for:** Better phrasing, handles longer threads
 
-These appear in `models/registry.json` with stable IDs and filenames:
+### Pro (12–16+ GB RAM)
 
-- **Starter — Phi-3 Mini Instruct (Q4_K_M)** — MIT  
-  `id: starter-phi3-mini-q4_k_m`  
-  `file: phi-3-mini-instruct-q4_k_m.gguf`  
-  Context: 4k • Great default if unsure
+- **Model:** Qwen2.5 7B Instruct (Q4_K_M)
+- **File:** `qwen2.5-7b-instruct-q4_k_m.gguf`
+- **Context:** 8192 tokens
+- **License:** Apache-2.0
+- **Best for:** Best quality in this size, prefers 16 GB
 
-- **Standard — Mistral 7B Instruct (Q4_K_M)** — Apache-2.0  
-  `id: standard-mistral-7b-q4_k_m`  
-  `file: mistral-7b-instruct-q4_k_m.gguf`  
-  Context: 8k • Better phrasing on modern laptops
-
-- **Pro — Qwen2.5 7B Instruct (Q4_K_M)** — Apache-2.0  
-  `id: pro-qwen2_5-7b-q4_k_m`  
-  `file: qwen2.5-7b-instruct-q4_k_m.gguf`  
-  Context: 8k • Best quality here; prefers ≥16 GB RAM
-
-> **USB sizing tip:** For one 7B model, a **16 GB** USB is comfortable. For multiple models, **32 GB+**.
+> **Note:** These are **Q4_K_M** quantizations — a good balance of quality and size. For the smallest possible size, try Q4_0. For best quality, try Q5_K_M or Q6_K (requires more RAM).
 
 ---
 
-## Verify a downloaded model (optional but recommended)
+## Setting Up a Model
 
-After downloading a `.gguf` file, you can verify its SHA-256 against the registry:
+### Step 1: Download a GGUF file
 
-    npm run models:verify -- /path/to/model.gguf
+Find a compatible `.gguf` model from a trusted source:
 
-- If the registry entry’s `sha256` is empty, the tool prints the **computed hash** — copy it into `models/registry.json` for that model.
-- Run the command again; it should report `"ok": true`.
+- [Hugging Face](https://huggingface.co/models?library=gguf) (search for GGUF quantizations)
+- Official model releases (Phi-3, Mistral, Qwen2.5, etc.)
 
-> Keep models on your **USB**. Do **not** commit weights to this repo.
+**Important:** Make sure the filename matches one in `models/registry.json`, or be prepared to add a registry entry.
+
+**Example download links (for reference):**
+
+- Phi-3 Mini: Search Hugging Face for "microsoft/Phi-3-mini-4k-instruct-gguf"
+- Mistral 7B: Search for "mistralai/Mistral-7B-Instruct-v0.2-GGUF"
+- Qwen2.5 7B: Search for "Qwen/Qwen2.5-7B-Instruct-GGUF"
+
+### Step 2: Add the model
+
+```bash
+# From repo root
+npm run models:add -- ~/Downloads/phi-3-mini-instruct-q4_k_m.gguf
+```
+
+This will:
+
+1. Copy the file to `models/` with the correct name
+2. Verify the SHA-256 checksum (if configured in registry)
+3. Tell you what to do next
+
+**Expected output:**
+
+```
+📦 Adding model: phi-3-mini-instruct-q4_k_m.gguf
+📋 Copying to: /path/to/usb-llm/models/phi-3-mini-instruct-q4_k_m.gguf
+✅ Copy complete
+🔍 Verifying SHA-256...
+⚠️  No SHA-256 in registry for this model.
+Computed: abc123def456...
+
+To enable verification, add this hash to models/registry.json:
+  "sha256": "abc123def456..."
+
+✅ Model added (verification skipped)
+
+📚 Next steps:
+
+1. Set environment variable:
+   export USBLLM_MODEL_ID=starter-phi3-mini-q4_k_m
+
+2. Enable autostart (if using llama-server):
+   export USBLLM_AUTOSTART=1
+   export USBLLM_LLAMA_BIN=/path/to/llama-server
+
+3. Start the launcher:
+   npm run -w apps/launcher start
+
+4. Test with golden tasks:
+   npm run golden
+
+See docs/USAGE.md and docs/MODELS.md for more details.
+```
+
+### Step 3: List models
+
+```bash
+npm run models:list
+```
+
+Shows which models are in the registry and which are present on disk.
+
+**Example output:**
+
+```
+📋 Model Registry
+
+✅ Starter — Phi-3 Mini Instruct (Q4_K_M)
+   ID:       starter-phi3-mini-q4_k_m
+   File:     phi-3-mini-instruct-q4_k_m.gguf
+   License:  MIT
+   RAM:      4+ GB (8 GB recommended)
+   Status:   Present
+   SHA-256:  (not set)
+
+❌ Standard — Mistral 7B Instruct (Q4_K_M)
+   ID:       standard-mistral-7b-q4_k_m
+   File:     mistral-7b-instruct-q4_k_m.gguf
+   License:  Apache-2.0
+   RAM:      8+ GB (16 GB recommended)
+   Status:   Missing
+   SHA-256:  (not set)
+
+❌ Pro — Qwen2.5 7B Instruct (Q4_K_M)
+   ID:       pro-qwen2_5-7b-q4_k_m
+   File:     qwen2.5-7b-instruct-q4_k_m.gguf
+   License:  Apache-2.0
+   RAM:      12+ GB (16 GB recommended)
+   Status:   Missing
+   SHA-256:  (not set)
+
+Summary: 1/3 models present
+```
 
 ---
 
-## Related docs
+## Verifying Model Integrity
 
-- Running the launcher: see [`docs/USAGE.md`](./USAGE.md) (Stub / External Upstream / Autostart)
+If a model has a `sha256` field in `models/registry.json`, the `models:add` command automatically verifies it. If you want to manually verify an existing file:
+
+```bash
+npm run models:verify -- models/phi-3-mini-instruct-q4_k_m.gguf
+```
+
+**If SHA-256 is not set in registry:**
+
+```json
+{
+  "ok": null,
+  "file": "phi-3-mini-instruct-q4_k_m.gguf",
+  "id": "starter-phi3-mini-q4_k_m",
+  "computed_sha256": "abc123def456...",
+  "message": "No sha256 in registry; copy this hash into models/registry.json"
+}
+```
+
+Copy the hash into `models/registry.json` under the appropriate model entry to enable verification for future downloads.
+
+**If verification passes:**
+
+```json
+{
+  "ok": true,
+  "file": "phi-3-mini-instruct-q4_k_m.gguf",
+  "id": "starter-phi3-mini-q4_k_m",
+  "expected_sha256": "abc123...",
+  "computed_sha256": "abc123..."
+}
+```
+
+**If verification fails:**
+
+```json
+{
+  "ok": false,
+  "file": "phi-3-mini-instruct-q4_k_m.gguf",
+  "id": "starter-phi3-mini-q4_k_m",
+  "expected_sha256": "abc123...",
+  "computed_sha256": "xyz789..."
+}
+```
+
+Re-download the model from a trusted source.
+
+---
+
+## Testing with Golden Tasks
+
+After adding a model, test it with the golden tasks harness:
+
+```bash
+# Set up autostart
+export USBLLM_AUTOSTART=1
+export USBLLM_LLAMA_BIN=/path/to/llama-server
+export USBLLM_MODEL_ID=starter-phi3-mini-q4_k_m
+
+# Start launcher
+npm run -w apps/launcher start &
+
+# Wait for it to be ready
+sleep 5
+
+# Run golden tasks
+npm run golden
+
+# Stop launcher
+pkill -f "apps/launcher"
+```
+
+Real models should score much better than Stub mode on heuristics (greeting, CTA, length).
+
+---
+
+## Troubleshooting
+
+**"File not listed in registry":**
+
+- Your `.gguf` filename doesn't match any entry in `models/registry.json`
+- Either rename it to match, or add a new entry to the registry
+
+**SHA-256 mismatch:**
+
+- File may be corrupted or from an untrusted source
+- Re-download from the official source
+
+**Model is too slow:**
+
+- Try a smaller quantization (Q4_0) or a smaller model (Phi-3 Mini)
+- Reduce context size: `export USBLLM_CTX_SIZE=2048`
+
+**Out of memory errors:**
+
+- Model is too large for your RAM
+- Try the Starter tier (Phi-3 Mini) or reduce context size
+
+**llama-server not found:**
+
+- Download llama.cpp from https://github.com/ggerganov/llama.cpp
+- Build or download the `llama-server` binary for your platform
+- Set `USBLLM_LLAMA_BIN` to the full path
+
+---
+
+## Adding New Models to Registry
+
+To add a custom model to `models/registry.json`:
+
+```json
+{
+  "id": "custom-model-id",
+  "name": "Custom Model Name",
+  "file": "custom-model.gguf",
+  "license": "Apache-2.0",
+  "context": 4096,
+  "quant": "Q4_K_M",
+  "min_ram_gb": 4,
+  "recommended_ram_gb": 8,
+  "notes": "Brief description",
+  "sha256": ""
+}
+```
+
+After adding to registry:
+
+1. Place the `.gguf` file in `models/` or use `models:add`
+2. Run `models:verify` to compute the SHA-256
+3. Copy the hash into the registry entry
+
+---
+
+## Next Steps
+
+After setting up a model:
+
+1. Follow `docs/USAGE.md` for detailed launcher configuration
+2. Run `npm run golden` to validate quality with the golden tasks
+3. Use the UI (`npm run -w apps/ui dev`) for interactive email drafting

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "models:add": "node scripts/model-helper.mjs add",
+    "models:list": "node scripts/model-helper.mjs list",
     "models:verify": "node scripts/verify-model.mjs",
-    "models:help": "node -e \"console.log('Usage: npm run models:verify -- <path/to/model.gguf>')\"",
+    "models:help": "node scripts/model-helper.mjs --help",
     "golden": "node packages/golden/golden.mjs"
   },
   "description": "USB-LLM is a plug-and-play offline email-drafting assistant that runs from a USB stick on Windows & macOS. No install. No cloud. v0.1 focuses on Reply, Compose, and Rewrite with tone/length presets and one-click copy.",

--- a/scripts/model-helper.mjs
+++ b/scripts/model-helper.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+/**
+ * Model helper CLI — manage .gguf models in the models/ directory
+ * Commands:
+ *   add <source>     Copy a .gguf file into models/ with registry filename
+ *   list             Show registry entries and files on disk
+ *   verify <path>    Verify SHA-256 (use models:verify instead)
+ */
+
+import { readFile, copyFile, access, readdir } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MODELS_DIR = join(__dirname, '..', 'models');
+const REG_PATH = join(__dirname, '..', 'models', 'registry.json');
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────
+
+async function loadRegistry() {
+  try {
+    const raw = await readFile(REG_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    return Array.isArray(data?.models) ? data.models : [];
+  } catch (e) {
+    console.error('Failed to read models/registry.json:', e instanceof Error ? e.message : e);
+    process.exit(2);
+  }
+}
+
+function sha256File(path) {
+  return new Promise((resolve, reject) => {
+    const h = createHash('sha256');
+    const s = createReadStream(path);
+    s.on('error', reject);
+    s.on('data', (chunk) => h.update(chunk));
+    s.on('end', () => resolve(h.digest('hex')));
+  });
+}
+
+async function fileExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Command: add <source>
+// ──────────────────────────────────────────────────────────────────
+
+async function cmdAdd(sourcePath) {
+  if (!sourcePath) {
+    console.error('Usage: npm run models:add -- <path/to/model.gguf>');
+    process.exit(2);
+  }
+
+  const exists = await fileExists(sourcePath);
+  if (!exists) {
+    console.error(`Error: File not found: ${sourcePath}`);
+    process.exit(1);
+  }
+
+  const sourceBasename = basename(sourcePath);
+  console.log(`📦 Adding model: ${sourceBasename}`);
+
+  const registry = await loadRegistry();
+  const entry = registry.find((m) => m.file === sourceBasename);
+
+  if (!entry) {
+    console.error(`\n❌ File not listed in registry: ${sourceBasename}`);
+    console.error('\nAvailable models in registry:');
+    registry.forEach((m) => {
+      console.error(`  - ${m.file} (${m.name})`);
+    });
+    console.error('\nEither:');
+    console.error('  1. Rename your file to match a registry entry, or');
+    console.error('  2. Add a new entry to models/registry.json');
+    process.exit(1);
+  }
+
+  const destPath = join(MODELS_DIR, entry.file);
+  const destExists = await fileExists(destPath);
+
+  if (destExists) {
+    console.log(`⚠️  File already exists: ${destPath}`);
+    console.log('Verifying existing file...');
+  } else {
+    console.log(`📋 Copying to: ${destPath}`);
+    try {
+      await copyFile(sourcePath, destPath);
+      console.log('✅ Copy complete');
+    } catch (e) {
+      console.error('❌ Copy failed:', e instanceof Error ? e.message : e);
+      process.exit(1);
+    }
+  }
+
+  // Verify SHA-256
+  console.log('🔍 Verifying SHA-256...');
+  const computed = await sha256File(destPath);
+
+  if (!entry.sha256) {
+    console.log('\n⚠️  No SHA-256 in registry for this model.');
+    console.log(`Computed: ${computed}`);
+    console.log('\nTo enable verification, add this hash to models/registry.json:');
+    console.log(`  "sha256": "${computed}"`);
+    console.log('\n✅ Model added (verification skipped)');
+    printNextSteps(entry);
+    process.exit(0);
+  }
+
+  const expected = entry.sha256.toLowerCase();
+  const match = computed.toLowerCase() === expected;
+
+  if (match) {
+    console.log('✅ SHA-256 verified');
+    console.log(`   Expected: ${expected}`);
+    console.log(`   Computed: ${computed}`);
+    console.log('\n✅ Model added successfully');
+    printNextSteps(entry);
+    process.exit(0);
+  } else {
+    console.error('\n❌ SHA-256 MISMATCH');
+    console.error(`   Expected: ${expected}`);
+    console.error(`   Computed: ${computed}`);
+    console.error('\nThis file may be:');
+    console.error('  - Corrupted during download');
+    console.error('  - The wrong file (different quantization or version)');
+    console.error('  - From an untrusted source');
+    console.error('\nRecommendation: Re-download from the official source and try again.');
+    process.exit(1);
+  }
+}
+
+function printNextSteps(entry) {
+  console.log('\n📚 Next steps:');
+  console.log(`\n1. Set environment variable:`);
+  console.log(`   export USBLLM_MODEL_ID=${entry.id}`);
+  console.log(`\n2. Enable autostart (if using llama-server):`);
+  console.log(`   export USBLLM_AUTOSTART=1`);
+  console.log(`   export USBLLM_LLAMA_BIN=/path/to/llama-server`);
+  console.log(`\n3. Start the launcher:`);
+  console.log(`   npm run -w apps/launcher start`);
+  console.log(`\n4. Test with golden tasks:`);
+  console.log(`   npm run golden`);
+  console.log(`\nSee docs/USAGE.md and docs/MODELS.md for more details.`);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Command: list
+// ──────────────────────────────────────────────────────────────────
+
+async function cmdList() {
+  console.log('📋 Model Registry\n');
+
+  const registry = await loadRegistry();
+
+  if (registry.length === 0) {
+    console.log('No models in registry.');
+    process.exit(0);
+  }
+
+  let files;
+  try {
+    files = await readdir(MODELS_DIR);
+  } catch {
+    files = [];
+  }
+
+  const ggufFiles = files.filter((f) => f.endsWith('.gguf'));
+
+  for (const entry of registry) {
+    const onDisk = ggufFiles.includes(entry.file);
+    const icon = onDisk ? '✅' : '❌';
+    console.log(`${icon} ${entry.name}`);
+    console.log(`   ID:       ${entry.id}`);
+    console.log(`   File:     ${entry.file}`);
+    console.log(`   License:  ${entry.license}`);
+    console.log(
+      `   RAM:      ${entry.min_ram_gb}+ GB (${entry.recommended_ram_gb} GB recommended)`
+    );
+    console.log(`   Status:   ${onDisk ? 'Present' : 'Missing'}`);
+    if (entry.sha256) {
+      console.log(`   SHA-256:  ${entry.sha256.slice(0, 16)}...`);
+    } else {
+      console.log(`   SHA-256:  (not set)`);
+    }
+    console.log('');
+  }
+
+  const extraFiles = ggufFiles.filter((f) => !registry.some((e) => e.file === f));
+  if (extraFiles.length > 0) {
+    console.log('⚠️  Unrecognized .gguf files in models/:');
+    extraFiles.forEach((f) => console.log(`   - ${f}`));
+    console.log('\nThese files are not in the registry and will be ignored.\n');
+  }
+
+  const presentCount = registry.filter((e) => ggufFiles.includes(e.file)).length;
+  console.log(`Summary: ${presentCount}/${registry.length} models present`);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Main
+// ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`
+USB-LLM Model Helper
+
+Commands:
+  add <source>     Copy a .gguf file into models/ with registry filename
+  list             Show registry entries and files on disk
+  verify <path>    Verify SHA-256 (use: npm run models:verify -- <path>)
+
+Examples:
+  npm run models:add -- ~/Downloads/phi-3-mini-instruct-q4_k_m.gguf
+  npm run models:list
+  npm run models:verify -- models/phi-3-mini-instruct-q4_k_m.gguf
+
+See docs/MODELS.md for model recommendations and setup instructions.
+    `);
+    process.exit(0);
+  }
+
+  const cmd = args[0];
+  const cmdArgs = args.slice(1);
+
+  if (cmd === 'add') {
+    await cmdAdd(cmdArgs[0]);
+  } else if (cmd === 'list') {
+    await cmdList();
+  } else {
+    console.error(`Unknown command: ${cmd}`);
+    console.error('Run with --help for usage.');
+    process.exit(2);
+  }
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e);
+  process.exit(2);
+});


### PR DESCRIPTION
- Add scripts/model-helper.mjs with add/list commands
- models:add copies .gguf to models/ and verifies SHA-256 automatically
- models:list shows registry entries and disk status with friendly output
- Friendly error messages with actionable next steps
- Cross-platform support (macOS + Windows)
- Update MODELS.md with complete setup workflow and testing instructions
- Update README.md to reference models:add and golden tasks
- Root scripts: models:add, models:list, models:help
- SHA-256 verification happens automatically on add with clear output